### PR TITLE
Validate Length of List Description

### DIFF
--- a/docs/resources/list.md
+++ b/docs/resources/list.md
@@ -32,7 +32,7 @@ resource "twitter_list" "hashicorp" {
 
 ### Optional
 
-- **description** (String, Optional) The description to give the list. A list's description must be less than 24 characters.
+- **description** (String, Optional) The description to give the list. A list's description can be at most 100 characters.
 - **id** (String, Optional) The ID of this resource.
 - **members** (Set of String, Optional) The screen names of the user for whom to return results.
 - **mode** (String, Optional) Whether your list is public or private. Values can be `public` or `private`.
@@ -41,5 +41,4 @@ resource "twitter_list" "hashicorp" {
 
 - **slug** (String, Read-only)
 - **uri** (String, Read-only)
-
 

--- a/docs/resources/list.md
+++ b/docs/resources/list.md
@@ -32,7 +32,7 @@ resource "twitter_list" "hashicorp" {
 
 ### Optional
 
-- **description** (String, Optional) The description to give the list.
+- **description** (String, Optional) The description to give the list. A list's description must be less than 24 characters.
 - **id** (String, Optional) The ID of this resource.
 - **members** (Set of String, Optional) The screen names of the user for whom to return results.
 - **mode** (String, Optional) Whether your list is public or private. Values can be `public` or `private`.

--- a/internal/provider/resource_list.go
+++ b/internal/provider/resource_list.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	validateDesc     schema.SchemaValidateFunc
 	validateName     schema.SchemaValidateFunc
 	validateStringID schema.SchemaValidateFunc
 )
@@ -27,6 +28,9 @@ func init() {
 	// using IDs as strings due to built-in ID attribute already being a string...
 	idRegexp := regexp.MustCompile("\\d+")
 	validateStringID = validation.StringMatch(idRegexp, "must be an integeger")
+
+	descRegexp := regexp.MustCompile(".{0,100}")
+	validateDesc = validation.StringMatch(descRegexp, `must be less than 100 characters`)
 }
 
 func resourceList() *schema.Resource {
@@ -54,9 +58,10 @@ func resourceList() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"public", "private"}, false),
 			},
 			"description": {
-				Description: "The description to give the list.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:  "The description to give the list.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateDesc,
 			},
 			"members": {
 				Description: "The screen names of the user for whom to return results.",

--- a/internal/provider/resource_list.go
+++ b/internal/provider/resource_list.go
@@ -29,8 +29,7 @@ func init() {
 	idRegexp := regexp.MustCompile("\\d+")
 	validateStringID = validation.StringMatch(idRegexp, "must be an integeger")
 
-	descRegexp := regexp.MustCompile(".{0,100}")
-	validateDesc = validation.StringMatch(descRegexp, `must be less than 100 characters`)
+	validateDesc = validation. StringLenBetween(0, 100)
 }
 
 func resourceList() *schema.Resource {


### PR DESCRIPTION
The description of a Twitter List has a maximum length of 100
characters. This was previously not being validated by the provider.
This commit adds a validation function that will display an error
if too long of a description is specified.